### PR TITLE
Issue #83: Fix anonymous subscriptions erroneously disabled

### DIFF
--- a/simplenews.module
+++ b/simplenews.module
@@ -1007,6 +1007,7 @@ function simplenews_unsubscribe_blocked_accounts(array $uids = array()) {
   $query = db_select('simplenews_subscriber', 'ss')
     ->fields('ss', array('snid'));
   $query->join('users', 'u', 'u.uid = ss.uid');
+  $query->condition('u.uid', 0, '>');
   $query->condition('u.status', 0);
   // Ignore the anonymous/global user (uid 0) so anonymous subscribers are not
   // auto-unsubscribed on cron runs.


### PR DESCRIPTION
Fixes #83 - unfortunately not previously wiped out subscriptions (e.g. on cron runs)